### PR TITLE
Added support for Alerts in WeatherResponse

### DIFF
--- a/darkskyandroidlib/src/main/java/com/johnhiott/darkskyandroidlib/models/AlertPoint.java
+++ b/darkskyandroidlib/src/main/java/com/johnhiott/darkskyandroidlib/models/AlertPoint.java
@@ -1,0 +1,50 @@
+package com.johnhiott.darkskyandroidlib.models;
+
+public class AlertPoint {
+
+    private String title;
+    private long time;
+    private long expires;
+    private String description;
+    private String uri;
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public long getTime() {
+        return time;
+    }
+
+    public void setTime(long time) {
+        this.time = time;
+    }
+
+    public long getExpires() {
+        return expires;
+    }
+
+    public void setExpires(long expires) {
+        this.expires = expires;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getUri() {
+        return uri;
+    }
+
+    public void setUri(String uri) {
+        this.uri = uri;
+    }
+}

--- a/darkskyandroidlib/src/main/java/com/johnhiott/darkskyandroidlib/models/AlertsBlock.java
+++ b/darkskyandroidlib/src/main/java/com/johnhiott/darkskyandroidlib/models/AlertsBlock.java
@@ -1,6 +1,6 @@
 package com.johnhiott.darkskyandroidlib.models;
 
-public class AlertPoint {
+public class AlertsBlock {
 
     private String title;
     private long time;

--- a/darkskyandroidlib/src/main/java/com/johnhiott/darkskyandroidlib/models/WeatherResponse.java
+++ b/darkskyandroidlib/src/main/java/com/johnhiott/darkskyandroidlib/models/WeatherResponse.java
@@ -1,5 +1,7 @@
 package com.johnhiott.darkskyandroidlib.models;
 
+import java.util.List;
+
 public class WeatherResponse {
 
     private double latitude;
@@ -10,6 +12,8 @@ public class WeatherResponse {
     private DataBlock minutely;
     private DataBlock hourly;
     private DataBlock daily;
+
+    private List<AlertPoint> alerts;
 
     public double getLatitude() {
         return latitude;
@@ -41,5 +45,13 @@ public class WeatherResponse {
 
     public DataBlock getDaily() {
         return daily;
+    }
+
+    public List<AlertPoint> getAlerts() {
+        return alerts;
+    }
+
+    public void setAlerts(List<AlertPoint> alerts) {
+        this.alerts = alerts;
     }
 }

--- a/darkskyandroidlib/src/main/java/com/johnhiott/darkskyandroidlib/models/WeatherResponse.java
+++ b/darkskyandroidlib/src/main/java/com/johnhiott/darkskyandroidlib/models/WeatherResponse.java
@@ -13,7 +13,7 @@ public class WeatherResponse {
     private DataBlock hourly;
     private DataBlock daily;
 
-    private List<AlertPoint> alerts;
+    private List<AlertsBlock> alerts;
 
     public double getLatitude() {
         return latitude;
@@ -47,11 +47,11 @@ public class WeatherResponse {
         return daily;
     }
 
-    public List<AlertPoint> getAlerts() {
+    public List<AlertsBlock> getAlerts() {
         return alerts;
     }
 
-    public void setAlerts(List<AlertPoint> alerts) {
+    public void setAlerts(List<AlertsBlock> alerts) {
         this.alerts = alerts;
     }
 }

--- a/darkskyandroidlib/src/main/java/com/johnhiott/darkskyandroidlib/models/WeatherResponse.java
+++ b/darkskyandroidlib/src/main/java/com/johnhiott/darkskyandroidlib/models/WeatherResponse.java
@@ -12,7 +12,6 @@ public class WeatherResponse {
     private DataBlock minutely;
     private DataBlock hourly;
     private DataBlock daily;
-
     private List<AlertsBlock> alerts;
 
     public double getLatitude() {


### PR DESCRIPTION
I stumbled upon this lib, and I thought I would contribute as I am building an app which uses Forecast.io as weather source.

I just added a new POJO called AlertsBlock and added a list of Alerts to the WeatherResponse class, I tested it and it works fine. I have attached a screenshot of the debug output i got back.
![capture](https://cloud.githubusercontent.com/assets/7470898/8385058/80d1f3e4-1c13-11e5-945d-dee5ec0efc93.PNG)

Also attaching the json output from the API for reference
![capture1](https://cloud.githubusercontent.com/assets/7470898/8385092/afbb1d20-1c13-11e5-855f-54ffb58d8732.PNG)
