### PR TITLE
Update Dark Sky API endpoint

### DIFF
--- a/darkskyandroidlib/src/main/java/com/johnhiott/darkskyandroidlib/ForecastApi.java
+++ b/darkskyandroidlib/src/main/java/com/johnhiott/darkskyandroidlib/ForecastApi.java
@@ -7,7 +7,7 @@ public class ForecastApi {
     private static ForecastApi mInstance = null;
     private RestAdapter mRestAdapter;
 
-    private static final String BASE_API_URL = "https://api.forecast.io/forecast/";
+    private static final String BASE_API_URL = "https://api.darksky.net/forecast/";
 
     public static ForecastApi getInstance() {
         return mInstance;


### PR DESCRIPTION
Dar Sky API team sent an Email asking for all API users to update the base endpoint
to https://api.darksky.net ASAP.

This can be found in new Docs https://darksky.net/dev/docs/forecast